### PR TITLE
Update config.py for windows compatibility

### DIFF
--- a/src/dogecoinrpc/config.py
+++ b/src/dogecoinrpc/config.py
@@ -62,7 +62,7 @@ def read_default_config(filename=None):
         if platform.system() == "Darwin":
             location = 'Library/Application Support/Bitcoin/dogecoin.conf'
         elif platform.system() in ('Windows', 'Microsoft'): 
-            location = '\\AppData\\Roaming\\DogeCoin\\dogecoin.conf'
+            location = 'AppData\\Roaming\\DogeCoin\\dogecoin.conf'
         else:
             location = '.dogecoin/dogecoin.conf'
         filename = os.path.join(home, location)


### PR DESCRIPTION
Removed backslashes from the start of windows' file location so that os.path.join does not view it as an absolute filepath.
